### PR TITLE
Fix domain name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![GoDoc](https://godoc.org/github.com/Seryiza/goshikimori?status.svg)](https://godoc.org/github.com/Seryiza/goshikimori) [![Go Report Card](https://goreportcard.com/badge/github.com/seryiza/goshikimori)](https://goreportcard.com/report/github.com/seryiza/goshikimori)
 
 ## Описание
-Пакет предназначен для взаимодействия с [API Шикимори](https://shikimori.org/api/doc).
+Пакет предназначен для взаимодействия с [API Шикимори](https://shikimori.one/api/doc).
 
 ## Зависимости
 * [github.com/golang/oauth2](https://github.com/golang/oauth2)
@@ -16,7 +16,7 @@ go get github.com/seryiza/goshikimori
 
 ## Использование
 ### OAuth2
-Прежде всего, для OAuth2 потребуется создать приложение [на самом Шикимори](https://shikimori.org/oauth/applications). Для авторизации потребуется *название приложения*, *client id* и *client secret*.
+Прежде всего, для OAuth2 потребуется создать приложение [на самом Шикимори](https://shikimori.one/oauth/applications). Для авторизации потребуется *название приложения*, *client id* и *client secret*.
 
 ### Работа с API
 Объект `goshikimori.Shikimori` предназначен для взаимодействия с API Шикимори. Можно использовать через:
@@ -25,7 +25,7 @@ go get github.com/seryiza/goshikimori
 ```go
   // var shiki *goshikimori.Shikimori
 
-  resp, _ := shiki.Get("users/whoami")    // для GET https://shikimori.org/api/users/whoami
+  resp, _ := shiki.Get("users/whoami")    // для GET https://shikimori.one/api/users/whoami
   userJSON, _ := ioutil.ReadAll(resp.Body)
   fmt.Println(string(userJSON))
   // => {"id":206253,"nickname":"Seryiza",...,"locale":"ru"}

--- a/auth/endpoint.go
+++ b/auth/endpoint.go
@@ -9,6 +9,6 @@ const (
 
 // ShikimoriEndpoint for Shikimori OAuth2
 var ShikimoriEndpoint = oauth2.Endpoint{
-	AuthURL:  "https://shikimori.org/oauth/authorize",
-	TokenURL: "https://shikimori.org/oauth/token",
+	AuthURL:  "https://shikimori.one/oauth/authorize",
+	TokenURL: "https://shikimori.one/oauth/token",
 }

--- a/auth/login.go
+++ b/auth/login.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	createSessionURL = `https://shikimori.org/api/sessions`
+	createSessionURL = `https://shikimori.one/api/sessions`
 	jsonErrorKey     = "error"
 
 	authAgreeForm = "form.authorize"

--- a/models/messages.go
+++ b/models/messages.go
@@ -47,7 +47,7 @@ type MessageResult struct {
 }
 
 // MarkReadMessages - Mark messages as read or unread.
-// https://shikimori.org/api/doc/1.0/messages/read_all
+// https://shikimori.one/api/doc/1.0/messages/read_all
 type MarkReadMessages struct {
 	// IDs list separated by comma.
 	// Ex., "17,18,987654".
@@ -58,14 +58,14 @@ type MarkReadMessages struct {
 }
 
 // ReadAllMessages - Mark all messages as read
-// https://shikimori.org/api/doc/1.0/messages/read_all
+// https://shikimori.one/api/doc/1.0/messages/read_all
 type ReadAllMessages struct {
 	Frontend     bool   `json:"frontend"`
 	MessagesType string `json:"type"`
 }
 
 // DeleteAllMessages - Delete all messages
-// https://shikimori.org/api/doc/1.0/messages/delete_all
+// https://shikimori.one/api/doc/1.0/messages/delete_all
 type DeleteAllMessages struct {
 	Frontend     bool   `json:"frontend"`
 	MessagesType string `json:"type"`

--- a/models/users_test.go
+++ b/models/users_test.go
@@ -66,15 +66,15 @@ var someUserBrief = &models.UserBrief{
 	User: models.User{
 		ID:       386084,
 		Nickname: "SeryizasBot",
-		Avatar:   "https://dere.shikimori.org/system/users/x48/386084.png?1532088739",
+		Avatar:   "https://dere.shikimori.one/system/users/x48/386084.png?1532088739",
 		Image: models.UserImage{
-			X160: "https://dere.shikimori.org/system/users/x160/386084.png?1532088739",
-			X148: "https://dere.shikimori.org/system/users/x148/386084.png?1532088739",
-			X80:  "https://dere.shikimori.org/system/users/x80/386084.png?1532088739",
-			X64:  "https://dere.shikimori.org/system/users/x64/386084.png?1532088739",
-			X48:  "https://dere.shikimori.org/system/users/x48/386084.png?1532088739",
-			X32:  "https://dere.shikimori.org/system/users/x32/386084.png?1532088739",
-			X16:  "https://dere.shikimori.org/system/users/x16/386084.png?1532088739",
+			X160: "https://dere.shikimori.one/system/users/x160/386084.png?1532088739",
+			X148: "https://dere.shikimori.one/system/users/x148/386084.png?1532088739",
+			X80:  "https://dere.shikimori.one/system/users/x80/386084.png?1532088739",
+			X64:  "https://dere.shikimori.one/system/users/x64/386084.png?1532088739",
+			X48:  "https://dere.shikimori.one/system/users/x48/386084.png?1532088739",
+			X32:  "https://dere.shikimori.one/system/users/x32/386084.png?1532088739",
+			X16:  "https://dere.shikimori.one/system/users/x16/386084.png?1532088739",
 		},
 
 		LastOnlineAt: time.Time{},

--- a/requests.go
+++ b/requests.go
@@ -10,7 +10,7 @@ import (
 )
 
 // NewRequest returns request for Shikimori (add to method full address).
-// Ex., ("GET", "whoami", nil) => ("GET", "https://shikimori.org/api/whoami", nil)
+// Ex., ("GET", "whoami", nil) => ("GET", "https://shikimori.one/api/whoami", nil)
 func (shiki *Shikimori) NewRequest(httpMethod, shikiMethod string, body io.Reader) (*http.Request, error) {
 	fullURL := fmt.Sprintf(shiki.URLFormat, shikiMethod)
 	return http.NewRequest(httpMethod, fullURL, body)

--- a/shikimori.go
+++ b/shikimori.go
@@ -7,8 +7,8 @@ import (
 )
 
 const (
-	shikimoriAPI_v1 = "https://shikimori.org/api/%s"
-	shikimoriAPI_v2 = "https://shikimori.org/api/v2/%s"
+	shikimoriAPI_v1 = "https://shikimori.one/api/%s"
+	shikimoriAPI_v2 = "https://shikimori.one/api/v2/%s"
 )
 
 // Shikimori to send requests to Shikimori API


### PR DESCRIPTION
This PR replaces all occurrences of `shikimori.org` with the `shikimori.one` domain, which is now the primary one.